### PR TITLE
Add screenshots functionality and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,18 @@ Please note this will probably be made default in the next major version
 
 Automatically associate failing tests with a screenshot through the `testMetaData` tag.
 
-- Environment variable: `TEAMCITY_SCREENSHOTS=true`
-- Reporter Option: `teamcityScreenshots=true`
-- Default: `false`
+  - Environment variable: `TEAMCITY_SCREENSHOTS=true`
+  - Reporter Option: `teamcityScreenshots=true`
+  - Default: `false`
 
-- Environment variable: `SCREENSHOTS_ARTIFACTS_DIR="path/to/screenshots"`
-- Reporter Option: `screenshotsArtifactsDir=\"path/to/screenshots\"`
-- Default: `screenshots`
+  - Environment variable: `SCREENSHOTS_ARTIFACTS_DIR="path/to/screenshots"`
+  - Reporter Option: `screenshotsArtifactsDir=\"path/to/screenshots\"`
+  - Default: `screenshots`
 
-- Environment variable: `CYPRESS_INTEGRATION_FOLDER="path/to/integration"`
-- Reporter Option: `integrationFolder=\"path/to/integration\"`
-- Default: `cypress/integration`
-  - Note: Setting the environment variable will override the integration folder cypress uses to execute tests.
+  - Environment variable: `CYPRESS_INTEGRATION_FOLDER="path/to/integration"`
+  - Reporter Option: `integrationFolder=\"path/to/integration\"`
+  - Default: `cypress/integration`
+    - Note: Setting the environment variable will override the integration folder cypress uses to execute tests.
 
 ### Setting options
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ Please note this will probably be made default in the next major version
 - Environment variable: `RECORD_HOOK_FAILURES=true`
 - Reporter option: `recordHookFailures=true`
 
+### Associate Failing Tests with Screenshots
+
+Automatically associate failing tests with a screenshot through the `testMetaData` tag.
+
+- Environment variable: `TEAMCITY_SCREENSHOTS=true`
+- Reporter Option: `teamcityScreenshots=true`
+- Default: `false`
+
+- Environment variable: `SCREENSHOTS_ARTIFACTS_DIR="path/to/screenshots"`
+- Reporter Option: `screenshotsArtifactsDir=\"path/to/screenshots\"`
+- Default: `screenshots`
+
+- Environment variable: `CYPRESS_INTEGRATION_FOLDER="path/to/integration"`
+- Reporter Option: `integrationFolder=\"path/to/integration\"`
+- Default: `cypress/integration`
+  - Note: Setting the environment variable will override the integration folder cypress uses to execute tests.
+
 ### Setting options
 
 - Set with reporter-options:

--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -18,6 +18,7 @@ const TEST_FAILED_COMPARISON =
   "##teamcity[testFailed type='comparisonFailure' name='%s' message='%s' details='%s' captureStandardOutput='true' actual='%s' expected='%s' flowId='%s']";
 const TEST_END = "##teamcity[testFinished name='%s' duration='%s' flowId='%s']";
 const TEST_END_NO_DURATION = "##teamcity[testFinished name='%s' flowId='%s']";
+const TEST_METADATA_IMAGE = "##teamcity[testMetadata testName='%s' type='image' value='%s']";
 
 const Base = require("mocha").reporters.Base;
 const log = console.log;
@@ -123,6 +124,16 @@ function Teamcity(runner, options = {}) {
       } else {
         log(formatString(TEST_FAILED, test.title, err.message, err.stack, flowId));
       }
+    }
+    if (reporterOptions.teamcityScreenshots || process.env["TEAMCITY_SCREENSHOTS"]) {
+      const screenshotsArtifactsDir =
+        reporterOptions.screenshotsArtifactsDir || process.env["SCREENSHOTS_ARTIFACTS_DIR"] || "screenshots";
+      const cypressIntegrationDir =
+        reporterOptions.integrationFolder || process.env["CYPRESS_INTEGRATION_FOLDER"] || "cypress/integration";
+      const imgDir = `${test.parent.parent.file.split(`${cypressIntegrationDir}/`)[1]}`;
+      const img = `${test.parent.title} -- ${test.title} (failed).png`;
+      const fullImgPath = `${screenshotsArtifactsDir}/${imgDir}/${img}`;
+      log(formatString(TEST_METADATA_IMAGE, test.title, fullImgPath));
     }
   });
 

--- a/lib/teamcityBrowser.js
+++ b/lib/teamcityBrowser.js
@@ -37,10 +37,11 @@ function escape(str) {
  * @param {options} options
  * @api public
  */
-function teamcity(runner) {
+function teamcity(runner, options) {
   Base.call(this, runner);
   const stats = this.stats;
   const flowId = document.title || new Date().getTime();
+  const reporterOptions = options.reporterOptions || {};
 
   runner.on("suite", function (suite) {
     if (suite.root) return;
@@ -66,6 +67,16 @@ function teamcity(runner) {
         escape(err.stack) +
         "']"
     );
+    if (reporterOptions.teamcityScreenshots || process.env["TEAMCITY_SCREENSHOTS"]) {
+      const screenshotsArtifactsDir =
+        reporterOptions.screenshotsArtifactsDir || process.env["SCREENSHOTS_ARTIFACTS_DIR"] || "screenshots";
+      const cypressIntegrationDir =
+        reporterOptions.integrationFolder || process.env["CYPRESS_INTEGRATION_FOLDER"] || "cypress/integration";
+      const imgDir = `${test.parent.parent.file.split(`${cypressIntegrationDir}/`)[1]}`;
+      const img = `${test.parent.title} -- ${test.title} (failed).png`;
+      const fullImgPath = `${screenshotsArtifactsDir}/${imgDir}/${img}`;
+      log("##teamcity[testMetaData name='" + escape(test.title) + "' type='image' value='" + fullImgPath + "'");
+    }
   });
 
   runner.on("pending", function (test) {


### PR DESCRIPTION
# Proposed changes

Add functionality for associated failed cypress test with a screenshot, using Teamcity's `testMetaData` tag.
For customizability, requires adding the following options:
- `screenshots` -> boolean, enables/disabled the functionality. `false` by default.
- `screenshotsArtifactsDir` -> string, path to location of screenshots directory as an artifact on Teamcity. `screenshots` by default
- `integrationFolder` -> string, path to location of tests. Used to find image. `cypress/integration` by default, also can be accessed by the `CYPRESS_INTEGRATION_FOLDER` environment variable, which will affect which tests are run in cypress (definitely open to changing this to something else, but the assumption is that this variable will always equal that environment variable if set)

Notes: Won't work if screenshot names are changed _after_ test execution. I have not tested running it in the browser, but I'm not sure why it wouldn't work. Also did not do extensive testing with the `escape()` function for the imgPaths.

## Type of change

_Put an `x` in the boxes that apply_

- [ ] beta - A change not ready for production use
- [ ] patch - Bug fix (non-breaking change which fixes an issue)
- [x] minor - New feature (non-breaking change which adds functionality)
- [ ] major - New release or breaking changes (fix or feature that would cause existing functionality to not work as expected)

Considered minor since the functionality is disabled by default.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] ESLint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

I did not add any unit tests, but and I'm little unsure how they would be useful here, but more than happy to work with you to create them to your liking :)

Additionally, there wasn't an open issue or anything for this, but it was functionality I wanted in my test suite and after implementing it, I realized it would be pretty straightforward to add back into this reporter.